### PR TITLE
Removed Discord Key

### DIFF
--- a/PeoplezBot.py
+++ b/PeoplezBot.py
@@ -176,4 +176,4 @@ async def owo(*, args):
     hold = join
     await bot.say(join)
 
-bot.run('MzIyNTUwNjAyMTcxMTU0NDMz.DSidFg.ifKsPdbn-PoZAcuDkiDxvDkpTvE')
+bot.run()


### PR DESCRIPTION
Removed the discord key, so that people can not use the bot with the associated account, without permission.